### PR TITLE
[バック]投稿評価APIに追加時にviewed_sentencesテーブルのレコードがなかったらエラーにする(cnv-157)

### DIFF
--- a/app/controllers/v1/evaluations_controller.rb
+++ b/app/controllers/v1/evaluations_controller.rb
@@ -11,12 +11,29 @@
 module V1
   # EvaluationsController
   class EvaluationsController < ApplicationController
+    include ErrorResponseHelper
+
     # POST /v1/evaluations
     # rubocop:disable Metrics/AbcSize
     def create
       # パラメータの存在チェック
       required_keys = %w[sentenceId evaluation]
       return unless check_required_keys(params, required_keys)
+
+      # sentenceIdの値が実際に存在するかチェック
+      unless Sentence.exists?(sentence_id: evaluation_params[:sentenceId])
+        render_error_response(422, '指定された投稿が存在しません。')
+        return
+      end
+
+      # 投稿を閲覧済みかチェック
+      unless ViewedSentence.exists?(viewed_sentence_id: evaluation_params[:sentenceId], viewed_user_id: current_user_id)
+        Rails.logger.error(
+          "[ERROR] この投稿を閲覧していないため評価できません。 - sentenceId: #{evaluation_params[:sentenceId]}, userId: #{current_user_id}"
+        )
+        render_error_response(403, 'この投稿を閲覧していないため評価できません。')
+        return
+      end
 
       evaluation = Evaluation.find_or_initialize_by(sentence_id: evaluation_params[:sentenceId],
                                                     evaluator_user_id: current_user_id)

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -61,6 +61,40 @@ RSpec.describe 'Evaluations', type: :request do
       end
     end
 
+    context 'when sentenceId is missing' do
+      it 'returns a required parameter error' do
+        post('/v1/evaluations', params: { evaluation: 'good' }) # sentenceIdなし
+        json_response = JSON.parse(response.body)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['error']['code']).to eq(422)
+        expect(json_response['error']['message']).to include('必須項目が不足しています')
+        expect(json_response['error']['message']).to include('sentenceId')
+      end
+    end
+
+    context 'when evaluation is missing' do
+      it 'returns a required parameter error' do
+        post('/v1/evaluations', params: { sentenceId: sentence.sentence_id }) # evaluationなし
+        json_response = JSON.parse(response.body)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['error']['code']).to eq(422)
+        expect(json_response['error']['message']).to include('必須項目が不足しています')
+        expect(json_response['error']['message']).to include('evaluation')
+      end
+    end
+
+    context 'when both sentenceId and evaluation are missing' do
+      it 'returns a required parameter error for both' do
+        post('/v1/evaluations', params: {}) # 両方なし
+        json_response = JSON.parse(response.body)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['error']['code']).to eq(422)
+        expect(json_response['error']['message']).to include('必須項目が不足しています')
+        expect(json_response['error']['message']).to include('sentenceId')
+        expect(json_response['error']['message']).to include('evaluation')
+      end
+    end
+
     context 'When sentenceId does not exist' do
       it 'returns a validation failure message' do
         post('/v1/evaluations', params: valid_attributes.merge(sentenceId: 1000))

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe 'Evaluations', type: :request do
     before do
       # クッキーにJWTトークンを設定
       login_as(user)
+      # 閲覧済みレコードを追加
+      ViewedSentence.create!(
+        viewed_sentence_id: sentence.sentence_id,
+        viewed_user_id: user.user_id,
+        viewed_at: Time.current
+      )
     end
 
     context 'when the request is valid (good)' do
@@ -61,7 +67,7 @@ RSpec.describe 'Evaluations', type: :request do
         json_response = JSON.parse(response.body)
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_response['error']['code']).to eq(422)
-        expect(json_response['error']['message']).to include('投稿の評価に失敗しました。')
+        expect(json_response['error']['message']).to include('指定された投稿が存在しません。')
       end
     end
 
@@ -71,7 +77,7 @@ RSpec.describe 'Evaluations', type: :request do
         json_response = JSON.parse(response.body)
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_response['error']['code']).to eq(422)
-        expect(json_response['error']['message']).to include('投稿の評価に失敗しました。')
+        expect(json_response['error']['message']).to include('指定された投稿が存在しません。')
       end
     end
 
@@ -81,7 +87,7 @@ RSpec.describe 'Evaluations', type: :request do
         json_response = JSON.parse(response.body)
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_response['error']['code']).to eq(422)
-        expect(json_response['error']['message']).to include('投稿の評価に失敗しました。')
+        expect(json_response['error']['message']).to include('指定された投稿が存在しません。')
       end
     end
 

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -125,6 +125,22 @@ RSpec.describe 'Evaluations', type: :request do
       end
     end
 
+    context 'when the user has not viewed the sentence' do
+      let(:other_user) { create(:user) }
+
+      before do
+        login_as(other_user)
+      end
+
+      it 'returns a forbidden error' do
+        post('/v1/evaluations', params: { sentenceId: sentence.sentence_id, evaluation: 'good' })
+        json_response = JSON.parse(response.body)
+        expect(response).to have_http_status(:forbidden)
+        expect(json_response['error']['code']).to eq(403)
+        expect(json_response['error']['message']).to include('この投稿を閲覧していないため評価できません。')
+      end
+    end
+
     context 'When evaluation is disabled' do
       it 'returns a validation failure message' do
         post('/v1/evaluations', params: valid_attributes.merge(evaluation: 'aaa'))


### PR DESCRIPTION
## JIRAチケットURL

https://techno-kuro-novel.atlassian.net/browse/CNV-157

---
## 実装内容

### 機能要件

このセクションでは、以下URL参照先（機能要件）の記載を引用し、どの要件を満たすための実装をしたのかを記載します。
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/3145744
なお、上記URLに含まれない実装をしている場合は、適宜参照先URLを付して、記載を引用して記載してください。
必ず製造タスクの根拠を示してください。

　例　テーブル定義Miroやその他資料

- 投稿評価APIに追加時に閲覧記録なかったらエラーにする機能を追加
- 既存であったリクエストparamが空かのチェックを閲覧記録の前に行う（テストを通すため）
- 既存であったリクエストのキー自体が存在しないかのチェックのテストを追加（テストがなかったため）

また、上記要件資料を参照し、漏れがないことを確認したら、チェックします。

[] 要件漏れがないことを確認済み
[] 一部懸念あり


### 非機能要件

このセクションでは、以下URL参照先（非機能要件）の記載を引用し、どの要件を満たすための実装をしたのかを記載します。
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/1376286/_PJ
なお、上記URLに含まれない実装をしている場合は、適宜参照先URLを付して、記載を引用して記載してください。

- 非機能要件1
- 非機能要件2
- 非機能要件3

以下非機能要件を遵守すべき事項を確認しチェック
[] CORS制約
[] XSS防止
[] CSRF防止
[] 認証中トークン
[] 広告枠

---

## テスト

[] テストコード作成済み（C1レベル確認済み）

## 自身で確認した動作のエビデンス（スクショ等）

### 動作確認エビデンス1
例　XX-API を パラメタ YY を ZZ として発行して、XX-API の取得値が変わる様子

### 動作確認エビデンス2

---
## 結合テスト・受入テストに持ち越すテスト項目（必ず1つ以上作成）
本PullReqで洗い出し記載して、Mergeしたら、以下に整理転記する
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/38567991

### テスト要求1

### テスト要求2

### テスト要求3
