### PR TITLE
[バック]main投稿が未評価だった場合に新規投稿を作成できなくする(CNV-236)

### DIFF
--- a/app/controllers/v1/sentences_controller.rb
+++ b/app/controllers/v1/sentences_controller.rb
@@ -66,6 +66,11 @@ module V1
         check_parent_sentence_updated(parent_sentence)
         check_consecutive_self_post(parent_sentence)
 
+        # 親投稿が未評価の場合は投稿不可
+        parent_evaluation = Evaluation.find_by(sentence_id: parent_sentence.sentence_id,
+                                               evaluator_user_id: current_user_id)
+        raise CustomError.new('親投稿が未評価のため、投稿できません。', 422) if parent_evaluation.nil?
+
         sentence = build_sentence(parent_sentence, sentence_text)
         sentence.save!
       end

--- a/spec/requests/sentences_spec.rb
+++ b/spec/requests/sentences_spec.rb
@@ -117,6 +117,20 @@ RSpec.describe 'Sentences', type: :request do
 
   # createのテスト
   describe 'POST /v1/sentences' do
+    context 'when parent sentence is not evaluated' do
+      it 'returns an error for unevaluated parent' do
+        unevaluated_parent = create(:sentence, user: users[1], title:)
+        post v1_sentences_path, params: {
+          parentSentenceId: unevaluated_parent.sentence_id,
+          sentence: 'テスト投稿',
+          parentUpdatedAt: unevaluated_parent.updated_at
+        }
+        expect(response).to have_http_status(:unprocessable_entity)
+        json_response = JSON.parse(response.body)
+        expect(json_response['error']['message']).to eq('親投稿が未評価のため、投稿できません。')
+      end
+    end
+
     context 'with valid parameters' do
       it 'creates a new Sentence' do
         # POSTの前にmain（投稿後はparentになる）を評価
@@ -139,6 +153,7 @@ RSpec.describe 'Sentences', type: :request do
 
     context 'when required parameters are missing' do
       it 'returns an unprocessable entity status' do
+        create(:evaluation, sentence: main_sentence, evaluator_user: users[2], evaluation: :good)
         post(v1_sentences_path, params: valid_attributes.merge(sentence: ''))
         expect(response).to have_http_status(:unprocessable_entity)
         json_response = JSON.parse(response.body)
@@ -149,6 +164,7 @@ RSpec.describe 'Sentences', type: :request do
 
     context 'when parent_sentence_id does not exist' do
       it 'returns an unprocessable entity status' do
+        create(:evaluation, sentence: main_sentence, evaluator_user: users[2], evaluation: :good)
         post(v1_sentences_path, params: valid_attributes.merge(parentSentenceId: 100))
         expect(response).to have_http_status(:unprocessable_entity)
         json_response = JSON.parse(response.body)
@@ -159,6 +175,7 @@ RSpec.describe 'Sentences', type: :request do
 
     context 'with invalid parameters' do
       it 'returns a conflict status' do
+        create(:evaluation, sentence: main_sentence, evaluator_user: users[2], evaluation: :good)
         post(v1_sentences_path, params: valid_attributes.merge(parentUpdatedAt: '2024-01-01T01:01:09.292+09:00'))
         expect(response).to have_http_status(:conflict)
         json_response = JSON.parse(response.body)
@@ -169,6 +186,7 @@ RSpec.describe 'Sentences', type: :request do
 
     context 'when consecutive self post is detected' do
       it 'returns an unprocessable entity status' do
+        create(:evaluation, sentence: main_sentence, evaluator_user: users[2], evaluation: :good)
         post_user_id = users[2].id # 連続投稿のユーザーID
         post(v1_sentences_path, params: valid_attributes.merge(parentSentenceId: post_user_id))
         expect(response).to have_http_status(:unprocessable_entity)
@@ -180,6 +198,7 @@ RSpec.describe 'Sentences', type: :request do
 
     context 'when sentence length exceeds the limit' do
       it 'returns an unprocessable entity status' do
+        create(:evaluation, sentence: main_sentence, evaluator_user: users[2], evaluation: :good)
         long_sentence = 'a' * 101
         post(v1_sentences_path, params: valid_attributes.merge(sentence: long_sentence))
         expect(response).to have_http_status(:unprocessable_entity)


### PR DESCRIPTION
## JIRAチケットURL

https://techno-kuro-novel.atlassian.net/browse/CNV-236

---
## 実装内容

- main投稿が未評価だった場合に新規投稿を作成できなくする

### 機能要件

このセクションでは、以下URL参照先（機能要件）の記載を引用し、どの要件を満たすための実装をしたのかを記載します。
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/3145744
なお、上記URLに含まれない実装をしている場合は、適宜参照先URLを付して、記載を引用して記載してください。
必ず製造タスクの根拠を示してください。

　例　テーブル定義Miroやその他資料


- 機能要件1
- 機能要件2
- 機能要件3

また、上記要件資料を参照し、漏れがないことを確認したら、チェックします。

[] 要件漏れがないことを確認済み
[] 一部懸念あり


### 非機能要件

このセクションでは、以下URL参照先（非機能要件）の記載を引用し、どの要件を満たすための実装をしたのかを記載します。
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/1376286/_PJ
なお、上記URLに含まれない実装をしている場合は、適宜参照先URLを付して、記載を引用して記載してください。

- 非機能要件1
- 非機能要件2
- 非機能要件3

以下非機能要件を遵守すべき事項を確認しチェック
[] CORS制約
[] XSS防止
[] CSRF防止
[] 認証中トークン
[] 広告枠

---

## テスト

[] テストコード作成済み（C1レベル確認済み）

## 自身で確認した動作のエビデンス（スクショ等）

### 動作確認エビデンス1
例　XX-API を パラメタ YY を ZZ として発行して、XX-API の取得値が変わる様子

<img width="617" height="200" alt="スクリーンショット 2025-11-27 9 25 03" src="https://github.com/user-attachments/assets/3175f78c-1082-4f64-8c7f-3f629b2c359a" />
<img width="617" height="154" alt="スクリーンショット 2025-11-27 9 25 09" src="https://github.com/user-attachments/assets/df64544d-4376-4ffc-9035-1f90d2e2033a" />
<img width="592" height="156" alt="スクリーンショット 2025-11-27 9 25 17" src="https://github.com/user-attachments/assets/193437ce-66c2-49b4-bf21-8935003795c6" />


### 動作確認エビデンス2

---
## 結合テスト・受入テストに持ち越すテスト項目（必ず1つ以上作成）
本PullReqで洗い出し記載して、Mergeしたら、以下に整理転記する
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/38567991

### テスト要求1

### テスト要求2

### テスト要求3
