### PR TITLE
未ログインかつ親投稿未評価のメソッド名を変更(CNV-231)

### DIFF
--- a/app/controllers/v1/sentences_controller.rb
+++ b/app/controllers/v1/sentences_controller.rb
@@ -38,16 +38,16 @@ module V1
       evaluation_counts = build_evaluation_counts(raw_counts)
 
       begin
-        login_or_parent_unevaluated = login_or_parent_unevaluated?(sentence, current_user_id)
+        restricted = restricted?(sentence, current_user_id)
         # 未ログイン時 or ログイン時は親があり未評価の場合は閲覧履歴を登録しない
-        if current_user_id.present? && !login_or_parent_unevaluated
+        if current_user_id.present? && !restricted
           process_viewed_sentence(sentence)
         else
           # rubocop:disable Layout/LineLength
-          Rails.logger.debug("[DEBUG]viewed_sentence(スキップ) - 条件未達: sentence.sentence_id: #{sentence.sentence_id}, user_id: #{current_user_id}, login_or_parent_unevaluated: #{login_or_parent_unevaluated}")
+          Rails.logger.debug("[DEBUG]viewed_sentence(スキップ) - 条件未達: sentence.sentence_id: #{sentence.sentence_id}, user_id: #{current_user_id}, restricted: #{restricted}")
           # rubocop:enable Layout/LineLength
         end
-        render json: build_response(sentence, user_evaluations, evaluation_counts, login_or_parent_unevaluated),
+        render json: build_response(sentence, user_evaluations, evaluation_counts, restricted),
                status: params[:status] || :ok
       rescue StandardError => e
         Rails.logger.error("Failed to create or update viewed_sentence record: #{e.message}")
@@ -116,7 +116,7 @@ module V1
     # 投稿レスポンスを構築
     # rubocop:disable Metrics/AbcSize
     def build_sentence_response(sentence, user_evaluations, evaluation_counts,
-                                is_main: false, login_or_parent_unevaluated: false)
+                                is_main: false, restricted: false)
       return nil if sentence.nil?
 
       user = sentence.user
@@ -126,7 +126,7 @@ module V1
 
       # mainのテキスト短縮条件： 未ログイン or 親投稿があり未評価
       sentence_text = sentence.sentence
-      sentence_text = truncated_main_sentence(sentence_text) if is_main && login_or_parent_unevaluated
+      sentence_text = truncated_main_sentence(sentence_text) if is_main && restricted
 
       {
         sentenceId: sentence.sentence_id,
@@ -154,23 +154,23 @@ module V1
     # 複数の投稿レスポンスを構築
     def build_sentence_responses(sentences, user_evaluations, evaluation_counts)
       sentences.map do |sentence|
-        build_sentence_response(sentence, user_evaluations, evaluation_counts, login_or_parent_unevaluated: false)
+        build_sentence_response(sentence, user_evaluations, evaluation_counts, restricted: false)
       end
     end
 
     # レスポンスを構築
-    def build_response(sentence, user_evaluations, evaluation_counts, login_or_parent_unevaluated)
+    def build_response(sentence, user_evaluations, evaluation_counts, restricted)
       data = build_response_data(sentence)
       evaluation_counts ||= {}
       data[:parent] ? user_evaluations[data[:parent].sentence_id]&.evaluation : nil
 
       # 未ログイン or 親があり未評価の場合はchildren, parallelsを非表示
-      parallels = if login_or_parent_unevaluated
+      parallels = if restricted
                     []
                   else
                     build_sentence_responses(data[:parallels], user_evaluations, evaluation_counts)
                   end
-      children  = if login_or_parent_unevaluated
+      children  = if restricted
                     []
                   else
                     build_sentence_responses(data[:children], user_evaluations, evaluation_counts)
@@ -179,9 +179,9 @@ module V1
       {
         main: build_sentence_response(data[:sentence], user_evaluations, evaluation_counts,
                                       is_main: true,
-                                      login_or_parent_unevaluated:),
+                                      restricted:),
         parent: build_sentence_response(data[:parent], user_evaluations, evaluation_counts,
-                                        login_or_parent_unevaluated: false),
+                                        restricted: false),
         parallels:,
         children:
       }
@@ -206,7 +206,7 @@ module V1
     end
 
     # 未ログイン or 親があり未評価の判定
-    def login_or_parent_unevaluated?(sentence, user_id)
+    def restricted?(sentence, user_id)
       has_parent = !sentence.parent.nil?
       parent_evaluation = if has_parent
                             Evaluation.find_by(sentence_id: sentence.parent.sentence_id,


### PR DESCRIPTION
## JIRAチケットURL

https://techno-kuro-novel.atlassian.net/browse/CNV-231

---
## 実装内容

フロントの直リンク時の見せ方を修正していて、「未ログインかつ親投稿未評価」の条件の変数を作っていて、
バックエンドで付けていた`login_or_parent_unevaluated`というメソッド名が
「未ログイン状態」ではなく「ログイン状態」が条件に感じられました。
→もう少しシンプルな`restricted`（制限あり）という名前に変更しました。

参考：フロントの変数名も`restricted`（制限あり）にしました
https://github.com/Conovel/frontend/pull/114/commits/dece8b2892963989ffa9ecfe870ba5a52ee152c1

※逆の意味の判定（ログインかつ親投稿を評価済み）にしてtrue、falseを反対にすることも考えましたが、
修正範囲が広範囲になったので、`restricted`（制限あり）の形にしたいです


### 機能要件

このセクションでは、以下URL参照先（機能要件）の記載を引用し、どの要件を満たすための実装をしたのかを記載します。
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/3145744
なお、上記URLに含まれない実装をしている場合は、適宜参照先URLを付して、記載を引用して記載してください。
必ず製造タスクの根拠を示してください。

　例　テーブル定義Miroやその他資料


- 機能要件1
- 機能要件2
- 機能要件3

また、上記要件資料を参照し、漏れがないことを確認したら、チェックします。

[] 要件漏れがないことを確認済み
[] 一部懸念あり


### 非機能要件

このセクションでは、以下URL参照先（非機能要件）の記載を引用し、どの要件を満たすための実装をしたのかを記載します。
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/1376286/_PJ
なお、上記URLに含まれない実装をしている場合は、適宜参照先URLを付して、記載を引用して記載してください。

- 非機能要件1
- 非機能要件2
- 非機能要件3

以下非機能要件を遵守すべき事項を確認しチェック
[] CORS制約
[] XSS防止
[] CSRF防止
[] 認証中トークン
[] 広告枠

---

## テスト

[] テストコード作成済み（C1レベル確認済み）

## 自身で確認した動作のエビデンス（スクショ等）

### 動作確認エビデンス1
例　XX-API を パラメタ YY を ZZ として発行して、XX-API の取得値が変わる様子

### 動作確認エビデンス2

---
## 結合テスト・受入テストに持ち越すテスト項目（必ず1つ以上作成）
本PullReqで洗い出し記載して、Mergeしたら、以下に整理転記する
https://techno-kuro-novel.atlassian.net/wiki/spaces/Conovel/pages/38567991

### テスト要求1

### テスト要求2

### テスト要求3
